### PR TITLE
Add warning for invalid licence in metadata

### DIFF
--- a/services_portal_site/templates/jasmin_services/includes/display_metadata.html
+++ b/services_portal_site/templates/jasmin_services/includes/display_metadata.html
@@ -2,6 +2,11 @@
     {% for metadata_item in metadata.all %}
         {% if metadata_item.key == 'licence_url' %}
             <p>The licence you agreed to when you made your application is available <a href="{{ metadata_item.value }}" target="_blank">here</a>.</p>
+         
+            {% if metadata_item.value == 'https://artefacts.ceda.ac.uk/licences/missing_licence.pdf' %}
+                <p><B>WARNING</B> this is not a valid licence.</p>
+            {% endif %}
+
         {% endif %}
     {% endfor %}
     <hr />


### PR DESCRIPTION
Add a warning if the licence used is a "missing" licence, which is not a proper licence at all, but users can still apply for these datasets. Mainly to warn the approver as otherwise they may not realise.

I have not tested this as I don't have a system set up to do so.

Ideally, the missing licence url would be defined in a settings file instead of being hardcoded.